### PR TITLE
fix: create .secrets directory before age-keygen in sops:keygen task

### DIFF
--- a/.taskfiles/sops/Taskfile.yml
+++ b/.taskfiles/sops/Taskfile.yml
@@ -10,7 +10,9 @@ vars:
 tasks:
   keygen:
     desc: "Generate Age key for SOPS encryption"
-    cmd: age-keygen --output {{.AGE_FILE}}
+    cmds:
+      - mkdir -p {{.ROOT_DIR}}/.secrets
+      - age-keygen --output {{.AGE_FILE}}
     status: ["test -f {{.AGE_FILE}}"]
     
   encrypt:


### PR DESCRIPTION
## Summary
- Fixed `sops:keygen` task failing with "no such file or directory" error
- Added `mkdir -p {{.ROOT_DIR}}/.secrets` command before `age-keygen` execution
- Allows `task sops:keygen` to run independently without requiring `task init` first

## Problem
The `sops:keygen` task was failing when the `.secrets` directory didn't exist:
```
age-keygen: error: failed to open output file "/home/pacman/iac-learning-template/.secrets/age.key": open /home/pacman/iac-learning-template/.secrets/age.key: no such file or directory
```

## Root Cause
- The `keygen` task tried to write directly to `.secrets/age.key`
- The directory creation was only in the `init` task
- Tasks should be independently executable

## Solution
Changed from single command to multiple commands:
```yaml
# Before
cmd: age-keygen --output {{.AGE_FILE}}

# After
cmds:
  - mkdir -p {{.ROOT_DIR}}/.secrets
  - age-keygen --output {{.AGE_FILE}}
```

## Test Plan
- [x] Verify task syntax is valid
- [ ] Test `task sops:keygen` in fresh clone without `.secrets` directory
- [ ] Verify `task bootstrap` still works end-to-end
- [ ] Confirm all other tasks still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)